### PR TITLE
Nearesttime multiple bands handling.

### DIFF
--- a/goes2go/data.py
+++ b/goes2go/data.py
@@ -609,8 +609,10 @@ def goes_nearesttime(
     # Get row that matches the nearest time
     df = df.sort_values("start")
     df = df.set_index(df.start)
-    nearest_time_index = df.index.get_indexer([attime], method="nearest")
-    df = df.iloc[nearest_time_index]
+    unique_times_index = df.index.unique()
+    nearest_time_index = unique_times_index.get_indexer([attime], method='nearest')
+    nearest_time = unique_times_index[nearest_time_index]
+    df = df.loc[nearest_time]
     df = df.reset_index(drop=True)
 
     n = len(df.file)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,100 @@
+from datetime import datetime, timedelta
+import unittest
+from unittest.mock import patch
+from venv import create
+
+import pandas as pd
+
+from goes2go.data import goes_nearesttime
+
+
+def _test_row(
+    satellite="G17",
+    product="ABI-L1b-RadC",
+    start=datetime(2021, 1, 1, 17, 0, 0),
+    band=1,
+    mode=6,
+):
+
+    return {
+        "file": "fname",
+        "product_mode": "pmode",
+        "satellite": satellite,
+        "start": start,
+        "end": start + timedelta(seconds=60),
+        "creation": start + timedelta(seconds=90),
+        "product": product,
+        "mode": mode,
+        "band": band,
+    }
+
+
+class TestData(unittest.TestCase):
+    def test_goes_nearesttime_singleband(self):
+
+        t = datetime(2021, 1, 1, 17, 0, 0)
+
+        with patch("goes2go.data._goes_file_df") as _goes_file_df_patched:
+
+            test_df = pd.DataFrame([_test_row(start=t)])
+            _goes_file_df_patched.return_value = test_df
+
+            res = goes_nearesttime(
+                t,
+                satellite=17,
+                product="ABI-L1b-Rad",
+                return_as="filelist",
+                bands=[1],
+                download=False,
+                domain="C",
+            )
+            self.assertEqual(len(res), 1)
+
+    def test_goes_nearesttime_multiband(self):
+
+        t = datetime(2021, 1, 1, 17, 0, 0)
+
+        with patch("goes2go.data._goes_file_df") as _goes_file_df_patched:
+
+            # test case where both have the same time, 2 res expected
+            test_df = pd.DataFrame(
+                [
+                    _test_row(start=t, band=1),
+                    _test_row(start=t, band=2),
+                ]
+            )
+            _goes_file_df_patched.return_value = test_df
+            res = goes_nearesttime(
+                t,
+                satellite=17,
+                product="ABI-L1b-Rad",
+                return_as="filelist",
+                bands=[1, 2],
+                download=False,
+                domain="C",
+            )
+            self.assertEqual(len(res), 2)
+
+            # test case where both have different time, 1 res expected
+            test_df = pd.DataFrame(
+                [
+                    _test_row(start=t, band=1),
+                    _test_row(start=t + timedelta(days=1), band=2),
+                ]
+            )
+            _goes_file_df_patched.return_value = test_df
+            res = goes_nearesttime(
+                t,
+                satellite=17,
+                product="ABI-L1b-Rad",
+                return_as="filelist",
+                bands=[1, 2],
+                download=False,
+                domain="C",
+            )
+            self.assertEqual(len(res), 1)
+            self.assertEqual(res.start[0], t)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses #28 

Searching for files by nearest time yields an error when multiple bands exist for the same timestamp. This change resolves that by first finding the nearest value, then filtering the original df on that value.

Note, I didn't see a prevailing approach to unit testing so I just used Python's built in:

```
python -m unittest tests/test_data.py
```