### PR TITLE
Replace assert with raise ValueError

### DIFF
--- a/docs/_build/html/_sources/user_guide/defaults.rst.txt
+++ b/docs/_build/html/_sources/user_guide/defaults.rst.txt
@@ -33,7 +33,7 @@ The default is
     return_as = "xarray"
 
     [nearesttime]
-    within = "1H"
+    within = "1h"
     return_as = "xarray"
 
 The ``[default]`` section are global settings used by each download method. These can be overwritten for each method. For instance, *s3_refresh* is set to false for ``[timerange]`` because it's unlikely you will need to refresh the file listing. Also, ``[latest]`` and ``[nearesttime]`` are by default returned as an xarray object instead of a list of files downloaded.

--- a/docs/user_guide/notebooks/DEMO_download_goes_single_point_timerange.ipynb
+++ b/docs/user_guide/notebooks/DEMO_download_goes_single_point_timerange.ipynb
@@ -30,10 +30,7 @@
    "source": [
     "import sys\n",
     "sys.path.append(\"../../../\")\n",
-    "from goes2go.data import goes_single_point_timerange\n",
-    "\n",
-    "from datetime import datetime\n",
-    "import pandas as pd"
+    "from goes2go.data import goes_single_point_timerange"
    ]
   },
   {

--- a/goes2go/NEW.py
+++ b/goes2go/NEW.py
@@ -7,15 +7,12 @@ GOES Class
 ==========
 """
 
-import itertools
 import logging
 import re
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 import s3fs
-import toml
 
 from goes2go import config
 from goes2go.data import _goes_file_df, goes_latest, goes_nearesttime, goes_timerange, goes_single_point_timerange

--- a/goes2go/__init__.py
+++ b/goes2go/__init__.py
@@ -24,7 +24,7 @@ import toml
 # TODO: Move some of the tools.py to these accessors.
 try:
     import goes2go.accessors
-except:
+except Exception:
     warnings.warn("goes2go xarray accessors could not be imported.")
 
 
@@ -80,7 +80,7 @@ s3_refresh = false
 return_as = "xarray"
 
 ["nearesttime"]
-within = "1H"
+within = "1h"
 return_as = "xarray"
 """
 
@@ -89,7 +89,7 @@ return_as = "xarray"
 try:
     # Load the goes2go config file
     config = toml.load(_config_file)
-except:
+except Exception:
     try:
         # Create the goes2go config file
         _config_path.mkdir(parents=True, exist_ok=True)
@@ -106,7 +106,7 @@ except:
 
         # Load the new goes2go config file
         config = toml.load(_config_file)
-    except (FileNotFoundError, PermissionError, IOError):
+    except (OSError, FileNotFoundError, PermissionError):
         print(
             f" ╭─goes2go─────────────────────────────────────────────╮\n"
             f" │ WARNING: Unable to create config file               │\n"

--- a/goes2go/accessors.py
+++ b/goes2go/accessors.py
@@ -3,7 +3,7 @@
 
 """
 ===========
-RGB Recipes
+RGB Recipes.
 ===========
 
 RGB Recipes for the GOES Advanced Baseline Imager.

--- a/goes2go/accessors.py
+++ b/goes2go/accessors.py
@@ -118,7 +118,7 @@ class fieldOfViewAccessor:
             )
             sat_height = ds.goes_imager_projection.perspective_point_height
             nadir_lon = ds.geospatial_lat_lon_extent.geospatial_lon_nadir
-            nadir_lat = ds.geospatial_lat_lon_extent.geospatial_lat_nadir
+            # nadir_lat = ds.geospatial_lat_lon_extent.geospatial_lat_nadir
         elif ds.cdm_data_type == "Point":
             globe_kwargs = dict(
                 semimajor_axis=ds.goes_lat_lon_projection.semi_major_axis,
@@ -127,7 +127,7 @@ class fieldOfViewAccessor:
             )
             sat_height = ds.nominal_satellite_height.item() * 1000
             nadir_lon = ds.lon_field_of_view.item()
-            nadir_lat = ds.lat_field_of_view.item()
+            # nadir_lat = ds.lat_field_of_view.item()
         # Create a cartopy coordinate reference system (crs)
         globe = ccrs.Globe(ellipse=None, **globe_kwargs)
 
@@ -258,9 +258,8 @@ class fieldOfViewAccessor:
         shapely.Polygon
         """
         ds = self._obj
-        assert ds.title.startswith(
-            "ABI"
-        ), "Domain polygon only available for ABI CONUS and Mesoscale files."
+        if not ds.title.startswith("ABI"):
+            raise ValueError("Domain polygon only available for ABI CONUS and Mesoscale files.")
         sat_height = ds.goes_imager_projection.perspective_point_height
         # Trim out domain FOV from the full disk (this is necessary for GOES-16).
         dom_border = np.array(
@@ -280,9 +279,8 @@ class rgbAccessor:
 
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
-        assert (
-            self._obj.title == "ABI L2 Cloud and Moisture Imagery"
-        ), "Dataset must be an ABI L2 Cloud and Moisture Imagery file."
+        if not self._obj.title == "ABI L2 Cloud and Moisture Imagery":
+            raise ValueError("Dataset must be an ABI L2 Cloud and Moisture Imagery file.")
         self._crs = None
         self._x = None
         self._y = None

--- a/goes2go/data.py
+++ b/goes2go/data.py
@@ -383,7 +383,7 @@ def goes_timerange(
         start = pd.to_datetime(start)
     if isinstance(end, str):
         end = pd.to_datetime(end)
-    # If `recent` is a string (like recent='1H'), parse with Pandas
+    # If `recent` is a string (like recent='1h'), parse with Pandas
     if isinstance(recent, str):
         recent = pd.to_timedelta(recent)
 
@@ -520,7 +520,7 @@ def goes_single_point_timerange(
         start = pd.to_datetime(start)
     if isinstance(end, str):
         end = pd.to_datetime(end)
-    # If `recent` is a string (like recent='1H'), parse with Pandas
+    # If `recent` is a string (like recent='1h'), parse with Pandas
     if isinstance(recent, str):
         recent = pd.to_timedelta(recent)
 

--- a/goes2go/data.py
+++ b/goes2go/data.py
@@ -3,8 +3,9 @@
 
 """
 =============
-Retrieve Data
+Retrieve Data.
 =============
+
 Download and read data from the R-series Geostationary Operational
 Environmental Satellite data.
 
@@ -216,7 +217,6 @@ def _download(df, save_dir, overwrite, max_threads=10, verbose=False):
 
 def _as_xarray_MP(src, save_dir, i=None, n=None, verbose=True):
     """Open a file as a xarray.Dataset -- a multiprocessing helper."""
-
     # File destination
     local_copy = Path(save_dir) / src
 
@@ -425,7 +425,7 @@ def goes_timerange(
 
 def _preprocess_single_point(ds, target_lat, target_lon, decimal_coordinates=True):
     """
-    Preprocessing function to select only the single relevant data subset
+    Preprocessing function to select only the single relevant data subset.
     
     Parameters
     ----------

--- a/goes2go/data.py
+++ b/goes2go/data.py
@@ -159,7 +159,7 @@ def _goes_file_df(satellite, product, start, end, bands=None, refresh=True):
         df["mode"] = mode_bands[0].str[1:].astype(int)
         try:
             df["band"] = mode_bands[1].astype(int)
-        except Exception:  # TODO: Specific specific exception(s)
+        except Exception:  # TODO: Specify specific expected exception(s)
             # No channel data
             df["band"] = None
 

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -1,11 +1,9 @@
 ## Brian Blaylock
 ## October 18, 2021
 
-"""
-Some simple tests for the ABI data
-"""
+"""Some simple tests for the ABI data."""
 
-from goes2go.data import goes_nearesttime, goes_latest, goes_timerange
+from goes2go.data import goes_nearesttime, goes_latest
 
 
 def test_nearesttime():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 import unittest
 from unittest.mock import patch
-from venv import create
 
 import pandas as pd
 

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1,11 +1,9 @@
 ## Brian Blaylock
 ## October 18, 2021
 
-"""
-Some simple tests for the GLM data
-"""
+"""Some simple tests for the GLM data."""
 
-from goes2go.data import goes_latest, goes_nearesttime, goes_timerange
+from goes2go.data import goes_latest, goes_nearesttime
 
 
 def test_nearesttime():


### PR DESCRIPTION
A potential solution for https://github.com/blaylockbk/goes2go/issues/98

All instances of assert (outside of tests) are replaced with Raise ValueError()

Also includes a linting changes and a few places where the to-be-depreciated "1H" has been changed to "1h". Unfortunately, one of those changes is within the __init__.py code which generates the initial `config.toml` file. As far as I can tell, this file will not be updated on the users system if they have previously imported goes2go and they will need to be instructed to manually update it.
