### PR TITLE
Fix SUVI data (ignore non-netcdf files in buckets)

### DIFF
--- a/goes2go/data.py
+++ b/goes2go/data.py
@@ -154,6 +154,7 @@ def _goes_file_df(satellite, product, start, end, bands=None, refresh=True, igno
     # Build a table of the files
     # --------------------------
     df = pd.DataFrame(files, columns=["file"])
+    df.drop(index=df.index[~df["file"].str.contains(".nc")],inplace=True)
     df[["product_mode", "satellite", "start", "end", "creation"]] = (
         df["file"].str.rsplit("_", expand=True, n=5).loc[:, 1:]
     )


### PR DESCRIPTION
SUVI images are given as NetCDF and FITS files (since August 23rd 2022 according to issue #102 ). This caused an error due to datetime parsing failing to match the file extension. We can just ignore the FITS files since they are duplicates of the netCDF files.